### PR TITLE
Make compatible with python redis 3

### DIFF
--- a/gluon/contrib/redis_session.py
+++ b/gluon/contrib/redis_session.py
@@ -144,6 +144,8 @@ class MockTable(object):
             # add it to the index
             pipe.sadd(self.id_idx, key)
             # set a hash key with the Storage
+            kwargs.pop('locked', None)  # remove the 'locked' key from kwargs - not needed for redis
+            kwargs['modified_datetime'] = str(kwargs['modified_datetime'])
             pipe.hmset(key, kwargs)
             if self.session_expiry:
                 pipe.expire(key, self.session_expiry)
@@ -220,6 +222,8 @@ class MockQuery(object):
             if not self.db.r_server.exists(key):
                 return None
             with self.db.r_server.pipeline() as pipe:
+                kwargs.pop('locked', None)  # remove the 'locked' key from kwargs - not needed for redis
+                kwargs['modified_datetime'] = str(kwargs['modified_datetime'])
                 pipe.hmset(key, kwargs)
                 if self.session_expiry:
                     pipe.expire(key, self.session_expiry)


### PR DESCRIPTION
Python redis recently moved from v2 to v3.  With this update it broke backwards compatibility.  See the details here:  https://pypi.org/project/redis/

V3 implements StrictRedis vs Redis which has been deprecated.

This change removes an unnecessary key from the parms passed to the pipe and changes the type of another.