### PR TITLE
Proposed fix for issue 2315

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -1501,7 +1501,7 @@ class SQLFORM(FORM):
             if readonly and not ignore_rw and not field.readable:
                 continue
 
-            if record:
+            if record and fieldname not in [x.name for x in extra_fields]:
                 default = record[fieldname]
             else:
                 default = field.default


### PR DESCRIPTION
See issue 2315.  Fixes error in web2py when using non database fields in extra_fields parameter of SQLFORM.

https://github.com/web2py/web2py/issues/2315